### PR TITLE
FIX Blank output caused by stale code in AST.subtree()

### DIFF
--- a/mayat/AST.py
+++ b/mayat/AST.py
@@ -60,7 +60,7 @@ class AST:
 
     def subtree(self, kind, name):
         def get_subtree_root(root, kind, name):
-            if root.kind.name == kind and root.name == name:
+            if root.kind == kind and root.name == name:
                 return root
 
             for child in root.children:

--- a/mayat/AST.py
+++ b/mayat/AST.py
@@ -3,6 +3,8 @@ from hashlib import sha256
 
 class ASTGenerationException(Exception):
     pass
+class ASTSearchException(Exception):
+    pass
 
 # Base class for Abstract Syntax Trees
 class AST:
@@ -70,7 +72,7 @@ class AST:
 
         subtree_root = get_subtree_root(self, kind, name)
         if subtree_root is None:
-            raise Exception("Cannot find specified kind and identifier name")
+            raise ASTSearchException("Cannot find specified kind and identifier name")
 
         return subtree_root
 

--- a/mayat/driver.py
+++ b/mayat/driver.py
@@ -3,7 +3,7 @@ import sys
 from datetime import datetime
 
 from mayat.Checker import Checker
-from mayat.AST import AST, ASTGenerationException
+from mayat.AST import AST, ASTGenerationException, ASTSearchException
 from mayat.Configurator import Configuration, Checkpoint
 
 
@@ -76,7 +76,7 @@ def driver(AST_class: AST, dir: str, config: Configuration, threshold: int=5, **
                 for path in asts:
                     try:
                         local_asts[path] = asts[path].subtree(kind, name)
-                    except:
+                    except ASTSearchException:
                         warnings.append(f"{path} doesn't have {name}:{kind}")
 
                 checkpoint_to_asts[(subpath, name, kind)] = local_asts


### PR DESCRIPTION
So while I was adding the python frontend, I changed `kind` from an object to a string. I changed most parts of the code to reflect this change except the one in `AST.subtree()`, which causes partial code checking unable to work properly. I'm fixing this in this PR.